### PR TITLE
(fix) removed _lc suffix from lc_objcat_udpater new_object_category v…

### DIFF
--- a/actions/lc_objcat_updater.py
+++ b/actions/lc_objcat_updater.py
@@ -19,7 +19,7 @@ class LC_ObjCat_Updater(BaseAction):
 
         # change obj cat with the LC name (as a basic example)
         changes = {
-            "new_object_category": "%s_lc" % (lc_type_name.value),
+            "new_object_category": "%s" % (lc_type_name.value),
         }
 
         payload.update(changes)


### PR DESCRIPTION
…alue.  updated local datastore to reflect the objcats in the test environment all ending in _lc.