### PR TITLE
(fix) typo in lc_objcat_updater.yaml

### DIFF
--- a/actions/lc_objcat_updater.yaml
+++ b/actions/lc_objcat_updater.yaml
@@ -1,5 +1,5 @@
 ---
-name: udpate_object_category_by_lifecycle_id 
+name: update_object_category_by_lifecycle_id 
 runner_type: run-python
 description: 'Update a devices object category and more  on D42 based on an incoming lifecycle event ID.  ' 
 enabled: true


### PR DESCRIPTION
Simple fix for typo in action name lc_objcat_updater.yaml.  